### PR TITLE
Embed version & multiple tabs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,8 +33,9 @@ user     | `string` | `<required>` |                          | `null`    | [cod
 hash     | `string` | `<required>` |                          | `null`    | the hash id of the pen to display.
 height   | `string` | `<optional>` | `px, %`                  | `250px`   | the height of the pen.
 width    | `string` | `<optional>` | `px, %`                  | `100%`    | the width of the pen.
-tab      | `string` | `<optional>` | `css, html, js, result`  | `result`  | the default tab that should be displayed.
 theme    | `string` | `<optional>` |                          | `default` | the theme the pen should use.
+version  | `number` | `<optional>` |                          | 2         | the embed version codepen should use.
+tab      | `string` | `<optional>` | `css`, `html`, `js`, `result`, `css,js`, `result,css`, etc  | `result`  | the default tab that should be displayed.
 
 
 ## Developing

--- a/src/react-codepen.js
+++ b/src/react-codepen.js
@@ -7,8 +7,20 @@ const Codepen = React.createClass({
     hash: React.PropTypes.string.isRequired,
     height: React.PropTypes.string,
     width: React.PropTypes.string,
-    tab: React.PropTypes.oneOf(['html', 'css', 'result', 'js']),
-    theme: React.PropTypes.string
+    theme: React.PropTypes.string,
+    version: React.PropTypes.number,
+    tab(props, propName, componentName) {
+
+      // Valid tab props: `result`; `html`; `result,js`; `css,html`
+      // Invalid: `result,result`; `js,js`; `html`; `foo`
+      const TAB_REGEX = /^(result|js|css|html)(,(?!\1)(result|js|css|html)|)?$/gm;
+
+      if (!TAB_REGEX.test(props[propName])) {
+        return new Error(
+          `Invalid prop \`${propName}\` supplied to \`${componentName}\`. Validation failed.`
+        );
+      }
+    }
   },
 
   getDefaultProps () {
@@ -16,12 +28,13 @@ const Codepen = React.createClass({
       height: '250px',
       width: '100%',
       tab: 'result',
-      theme: '0'
+      theme: '0',
+      version: 2
     };
   },
 
   render () {
-    const src  = `//codepen.io/${this.props.user}/embed/${this.props.hash}/?height=${this.props.height}&theme-id=${this.props.theme}&default-tab=${this.props.tab}`;
+    const src  = `//codepen.io/${this.props.user}/embed/${this.props.hash}/?height=${this.props.height}&theme-id=${this.props.theme}&default-tab=${this.props.tab}&embed-version=${this.props.version}`;
     const user = `http://codepen.io/${this.props.user}`;
     const pen  = `${user}/pen/${this.props.hash}/`;
 


### PR DESCRIPTION
I added support to pass a new prop called `version`. This prop is set to `2` by default.

I also made it so that the `tab` prop can now accept two tabs separated by a comma, for example:
- `js,result`
- `css,js`
- `html,result`
- ... etc

Please let me know if there is anything else you would like me to address before merging :)

By the way this PR addresses issue #1 
